### PR TITLE
Update redis version dependency

### DIFF
--- a/minuteman.gemspec
+++ b/minuteman.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "minuteman"
-  s.version           = "1.0.3"
+  s.version           = "1.0.4"
   s.summary           = "Bit Analytics"
   s.description       = "Fast and furious tracking system using Redis bitwise operations"
   s.authors           = ["elcuervo"]


### PR DESCRIPTION
Also updated version to `1.0.4`, not sure if that's necessary. It seems Rubygems might be outdated?
