### PR TITLE
Treat each [year, month, day, hour] as a namespaces

### DIFF
--- a/lib/minuteman/keys_methods.rb
+++ b/lib/minuteman/keys_methods.rb
@@ -17,7 +17,7 @@ class Minuteman
         BIT_OPERATION_PREFIX,
         type,
         events.join("-")
-      ].join("_")
+      ].join(":")
     end
   end
 end

--- a/lib/minuteman/time_span.rb
+++ b/lib/minuteman/time_span.rb
@@ -10,7 +10,7 @@ class Minuteman
 
     attr_reader :key
 
-    DATE_FORMAT = "%s-%02d-%02d"
+    DATE_FORMAT = "%s:%02d:%02d"
     TIME_FORMAT = "%02d:%02d"
 
     # Public: Initializes the base TimeSpan class
@@ -30,7 +30,7 @@ class Minuteman
     #   date       - A given Time object
     #
     def build_key(event_name, date)
-      [Minuteman::PREFIX, event_name, date.join("-")].join("_")
+      [Minuteman::PREFIX, event_name, date.join("-")].join(":")
     end
   end
 end

--- a/lib/minuteman/time_spans/hour.rb
+++ b/lib/minuteman/time_spans/hour.rb
@@ -13,7 +13,7 @@ class Minuteman
     def time_format(date)
       full_date = DATE_FORMAT % [date.year, date.month, date.day]
       time = TIME_FORMAT % [date.hour, 0]
-      [full_date + " " + time]
+      [full_date + ":" + time]
     end
   end
 end

--- a/lib/minuteman/time_spans/minute.rb
+++ b/lib/minuteman/time_spans/minute.rb
@@ -13,7 +13,7 @@ class Minuteman
     def time_format(date)
       full_date = DATE_FORMAT % [date.year, date.month, date.day]
       time = TIME_FORMAT % [date.hour, date.min]
-      [full_date + " " + time]
+      [full_date + ":" + time]
     end
   end
 end


### PR DESCRIPTION
I'm not sure if you have specs for the time keys, but I found that's using them as namespaces would help specially if you have a redis browser.

![](https://cloud.githubusercontent.com/assets/21756/4602466/a2e7830c-513b-11e4-9fc5-edf301923773.png)
